### PR TITLE
adds apiVersion option to Jira configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ const config: PlaywrightTestConfig = {
         jira: {
           url: 'https://your-jira-url',
           type: 'cloud',
+          apiVersion: '1.0',
         },
         cloud: {
           client_id: '',
@@ -61,6 +62,7 @@ const config: PlaywrightTestConfig = {
         jira: {
           url: 'https://your-jira-url',
           type: 'server',
+          apiVersion: '1.0',
         },
         server: {
           token: 'YOUR_SERVER_TOKEN',
@@ -101,6 +103,7 @@ const config: PlaywrightTestConfig = {
         jira: {
           url: 'https://your-jira-url',
           type: 'server',
+          apiVersion: '1.0',
         },
         cloud: {
           client_id: '',
@@ -140,6 +143,7 @@ const config: PlaywrightTestConfig = {
         jira: {
           url: 'https://your-jira-url',
           type: 'server',
+          apiVersion: '1.0',
         },
         cloud: {
           client_id: '',
@@ -241,6 +245,7 @@ const config: PlaywrightTestConfig = {
         jira: {
           url: 'https://your-jira-url',
           type: 'server',
+          apiVersion: '1.0',
         },
         server: {
           token: 'YOUR_SERVER_TOKEN',

--- a/src/types/xray.types.ts
+++ b/src/types/xray.types.ts
@@ -1,24 +1,25 @@
-import { AxiosProxyConfig } from "axios";
+import { AxiosProxyConfig } from 'axios';
 
 export interface XrayOptions {
-    jira: {
-        url: string,
-        type: string
-    },
-    cloud?: {
-        client_id?: string;
-        client_secret?: string;
-    },
-    server?: {
-        token: string
-    }
-    projectKey: string;
-    testPlan: string;
-    testExecution?: string;
-    revision?: string;
-    description?: string;
-    testEnvironments?: string[];
-    version?: string;
-    debug: boolean;
-    proxy?: AxiosProxyConfig;
+  jira: {
+    url: string;
+    type: string;
+    apiVersion: string;
+  };
+  cloud?: {
+    client_id?: string;
+    client_secret?: string;
+  };
+  server?: {
+    token: string;
+  };
+  projectKey: string;
+  testPlan: string;
+  testExecution?: string;
+  revision?: string;
+  description?: string;
+  testEnvironments?: string[];
+  version?: string;
+  debug: boolean;
+  proxy?: AxiosProxyConfig;
 }

--- a/src/xray.service.ts
+++ b/src/xray.service.ts
@@ -18,6 +18,7 @@ export class XrayService {
   private readonly password: string;
   private readonly token: string;
   private readonly type: string;
+  private readonly apiVersion: string;
   private readonly requestUrl: string;
   private readonly options: XrayOptions;
   private axios: Axios;
@@ -40,6 +41,10 @@ export class XrayService {
     // Set Jira Server Type
     if (!options.jira.type) throw new Error('"jira.type" option is missed. Please, provide it in the config');
     this.type = options.jira.type;
+
+    // Set Jira API apiVersion
+    if (!options.jira.apiVersion) throw new Error('"jira.apiVersion" option is missed. Please, provide it in the config');
+    this.apiVersion = options.jira.apiVersion;
 
     // Init axios instance
     this.axios = axios;
@@ -95,7 +100,7 @@ export class XrayService {
         this.token = options.server?.token;
 
         // Set Request URL
-        this.requestUrl = this.xray + 'rest/raven/1.0';
+        this.requestUrl = this.xray + this.apiVersion !== '1.0' ? `rest/raven/${this.apiVersion}/api` : 'rest/raven/1.0';
 
         //Create Axios Instance with Auth
         this.axios = axios.create({


### PR DESCRIPTION
Took an initiative to add Support for Jira XRAY API version 2.0, which is missing from this package.

This package makes life so much easier, that it's better to contribute, over creating our custom solution.

Made final solution this way, to avoid introducing breaking changes for other users of this package.

Here is link to XRAY [documentation](https://docs.getxray.app/display/XRAY/REST+API) about both API versions.
