### PR TITLE
excludes setup and cleanup projects from reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ test('J79 | basic test', async ({ page }) => {
 
 Is it possible to add some optional values to the Test Execution ticket.
 
+`testedBrowser` - The browser that should be reported to XRAY. Default is `undefined`. Othervise set it to equal the name field of project in `playwright.config.ts`. E.g. `chromium`, `firefox`, `webkit`.
+
 ```typescript
 // playwright.config.ts
 import { PlaywrightTestConfig } from '@playwright/test';
@@ -131,7 +133,8 @@ const config: PlaywrightTestConfig = {
         stepCategories: ['test.step'],
         summary: `[${new Date().toLocaleString('fr-FR', { timeZone: 'Europe/Paris' })}] - Automated`,
         dryRun: false,
-        runResult: true
+        runResult: true,
+        testedBrowser: 'chromium',
       },
     ],
   ],

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ test('J79 | basic test', async ({ page }) => {
 
 Is it possible to add some optional values to the Test Execution ticket.
 
-`testedBrowser` - The browser that should be reported to XRAY. Default is `undefined`. Othervise set it to equal the name field of project in `playwright.config.ts`. E.g. `chromium`, `firefox`, `webkit`.
+`projectsToExclude` - The Playwright projects that should not be reported to XRAY. Default is `undefined`. Othervise set it to array of values or to a single value, that is equal the name field of project in `playwright.config.ts`. E.g. [`setup`, `cleanup`] or `setup`.
 
 ```typescript
 // playwright.config.ts
@@ -134,7 +134,7 @@ const config: PlaywrightTestConfig = {
         summary: `[${new Date().toLocaleString('fr-FR', { timeZone: 'Europe/Paris' })}] - Automated`,
         dryRun: false,
         runResult: true,
-        testedBrowser: 'chromium',
+        projectsToExclude: ['setup', 'cleanup'],
       },
     ],
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,15 +53,14 @@ class XrayReporter implements Reporter {
     if (this.options.summary !== undefined) this.testResults.info.summary = this.options.summary;
     this.execInfo = {
       browserName: '',
-      testedBrowser: undefined,
+      testedBrowser: options.testedBrowser || undefined,
     };
   }
 
   onBegin(config: FullConfig, suite: Suite) {
-    config.projects.forEach((p, index) => {
+    config.projects.filter((p) => !/^(setup | cleanup)$/.test(p.name)).forEach((p, index) => {
       this.execInfo.browserName += index > 0 ? ', ' : '';
       this.execInfo.browserName += p.name.charAt(0).toUpperCase() + p.name.slice(1);
-      this.execInfo.testedBrowser = /^(cleanup | setup)$/.test(p.name) ? undefined : p.name;
     });
     if (this.options.dryRun) {
       console.log(`${bold(yellow('⏺  '))}${bold(blue(`Starting a Dry Run with ${suite.allTests().length} tests`))}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ class XrayReporter implements Reporter {
     if (this.options.summary !== undefined) this.testResults.info.summary = this.options.summary;
     this.execInfo = {
       browserName: '',
+      testedBrowser: undefined,
     };
   }
 
@@ -60,6 +61,7 @@ class XrayReporter implements Reporter {
     config.projects.forEach((p, index) => {
       this.execInfo.browserName += index > 0 ? ', ' : '';
       this.execInfo.browserName += p.name.charAt(0).toUpperCase() + p.name.slice(1);
+      this.execInfo.testedBrowser = /^(cleanup | setup)$/.test(p.name) ? undefined : p.name;
     });
     if (this.options.dryRun) {
       console.log(`${bold(yellow('⏺  '))}${bold(blue(`Starting a Dry Run with ${suite.allTests().length} tests`))}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ class XrayReporter implements Reporter {
   private uploadScreenShot: boolean | undefined;
   private uploadTrace: boolean | undefined;
   private uploadVideo: boolean | undefined;
+  private projectsToExclude: string | string[] | undefined;
   private stepCategories = ['expect', 'pw:api', 'test.step'];
   private readonly testsByKey: Map<string, TestResult[]>;
 
@@ -48,19 +49,44 @@ class XrayReporter implements Reporter {
       },
       tests: [] as XrayTest[],
     };
+    this.projectsToExclude = this.options.projectsToExclude;
     console.log(`${bold(blue('-------------------------------------'))}`);
     console.log(`${bold(blue(' '))}`);
     if (this.options.summary !== undefined) this.testResults.info.summary = this.options.summary;
     this.execInfo = {
       browserName: '',
-      testedBrowser: options.testedBrowser || undefined,
+      testedBrowser: undefined,
     };
   }
 
   onBegin(config: FullConfig, suite: Suite) {
-    config.projects.filter((p) => !/^(setup | cleanup)$/.test(p.name)).forEach((p, index) => {
+    let projectsToReport: Record<string, any>[] = [];
+    let regexOfExcludedProjects: RegExp;
+    // Exclude projects from the report
+    // If the projectsToExclude is an array, we will use the regex to exclude the projects
+    if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== 'string' && this.projectsToExclude.length > 1) {
+      regexOfExcludedProjects = new RegExp(`^(${this.projectsToExclude.join(' | ')})$`);
+      projectsToReport = config.projects.filter((p) => !regexOfExcludedProjects.test(p.name));
+    // If the projectsToExclude is a string, we will use the regex to exclude the projects
+    } else if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== 'string') {
+      regexOfExcludedProjects = new RegExp(`^(${this.projectsToExclude.join('')})$`);
+      projectsToReport = config.projects.filter((p) => !regexOfExcludedProjects.test(p.name));
+    // If the projectsToExclude is a string, we will use the regex to exclude the projects
+    } else if (this.projectsToExclude !== undefined && typeof this.projectsToExclude === 'string') {
+      regexOfExcludedProjects = new RegExp(`^(${this.projectsToExclude})$`);
+      projectsToReport = config.projects.filter((p) => !regexOfExcludedProjects.test(p.name));
+    // If the projectsToExclude is not defined, we will report all the projects
+    } else {
+      projectsToReport = config.projects;
+    }
+
+    projectsToReport.forEach((p, index) => {
       this.execInfo.browserName += index > 0 ? ', ' : '';
       this.execInfo.browserName += p.name.charAt(0).toUpperCase() + p.name.slice(1);
+      // Set the first browser as the tested browser
+      if (index === 0) {
+        this.execInfo.testedBrowser = p.name;
+      }
     });
     if (this.options.dryRun) {
       console.log(`${bold(yellow('⏺  '))}${bold(blue(`Starting a Dry Run with ${suite.allTests().length} tests`))}`);
@@ -69,7 +95,7 @@ class XrayReporter implements Reporter {
     }
 
     console.log(`${bold(blue(' '))}`);
-    if(this.execInfo.testedBrowser !== undefined) {
+    if (this.execInfo.testedBrowser !== undefined) {
       console.log(
         `${bold(yellow('⏺  '))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowser}`))}`,
       );
@@ -77,6 +103,8 @@ class XrayReporter implements Reporter {
   }
 
   async onTestBegin(test: TestCase) {
+    // Not sure if this is the best way to get the project name
+    // But let's keep it for now.
     if (this.execInfo.testedBrowser === undefined) {
       this.execInfo.testedBrowser = test.parent.parent?.title;
       console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ class XrayReporter implements Reporter {
     // Exclude projects from the report
     // If the projectsToExclude is an array, we will use the regex to exclude the projects
     if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== 'string' && this.projectsToExclude.length > 1) {
-      regexOfExcludedProjects = new RegExp(`^(${this.projectsToExclude.join(' | ')})$`);
+      regexOfExcludedProjects = new RegExp(`^(${this.projectsToExclude.join('|')})$`);
       projectsToReport = config.projects.filter((p) => !regexOfExcludedProjects.test(p.name));
     // If the projectsToExclude is a string, we will use the regex to exclude the projects
     } else if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,15 +70,20 @@ class XrayReporter implements Reporter {
     }
 
     console.log(`${bold(blue(' '))}`);
+    if(this.execInfo.testedBrowser !== undefined) {
+      console.log(
+        `${bold(yellow('⏺  '))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowser}`))}`,
+      );
+    }
   }
 
   async onTestBegin(test: TestCase) {
     if (this.execInfo.testedBrowser === undefined) {
       this.execInfo.testedBrowser = test.parent.parent?.title;
+      console.log(
+        `${bold(yellow('⏺  '))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowser}`))}`,
+      );
     }
-    console.log(
-      `${bold(yellow('⏺  '))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowser}`))}`,
-    );
   }
   async onTestEnd(testCase: TestCase, result: TestResult) {
     const testCaseId = testCase.title.match(this.testCaseKeyPattern);

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,10 +75,10 @@ class XrayReporter implements Reporter {
   async onTestBegin(test: TestCase) {
     if (this.execInfo.testedBrowser === undefined) {
       this.execInfo.testedBrowser = test.parent.parent?.title;
-      console.log(
-        `${bold(yellow('⏺  '))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowser}`))}`,
-      );
     }
+    console.log(
+      `${bold(yellow('⏺  '))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowser}`))}`,
+    );
   }
   async onTestEnd(testCase: TestCase, result: TestResult) {
     const testCaseId = testCase.title.match(this.testCaseKeyPattern);

--- a/src/types/xray.types.ts
+++ b/src/types/xray.types.ts
@@ -31,5 +31,5 @@ export interface XrayOptions {
   summary?: string;
   dryRun?: boolean;
   runResult?: boolean;
-  testedBrowser?: string;
+  projectsToExclude?: string | string[];
 }

--- a/src/types/xray.types.ts
+++ b/src/types/xray.types.ts
@@ -31,4 +31,5 @@ export interface XrayOptions {
   summary?: string;
   dryRun?: boolean;
   runResult?: boolean;
+  testedBrowser?: string;
 }


### PR DESCRIPTION
This is needed, to run tests in the correct browser, which won't end up being only `setup` job that logs user in and is done.
More about setup and cleanup can be found under `projects/dependencies` section in [Playwrigth documentation](https://playwright.dev/docs/test-projects#dependencies).

Playwright runs, that are now using setup and cleanup project dependencies, ends up now being able to send any report or even generate one.