### PR TITLE
adds support for basic auth with username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,55 @@ const config: PlaywrightTestConfig = {
 };
 ```
 
+## Authentication to Jira XRAY server
+Supports either token base auth or basic auth using username and password. 
+The token is the preferred method.
+
+If server option is used, then either token or username and password must be provided.
+But not both token and username plus password combination at the same time.
+
+## Using token based authentication
+
+```typescript
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  reporter: [
+    [
+      'playwright-xray',
+      {
+        server: {
+          token: '',
+        },
+      },
+    ],
+  ],
+};
+```
+
+## Using basic authentication
+
+```typescript
+// playwright.config.ts
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  reporter: [
+    [
+      'playwright-xray',
+      {
+        server: {
+          username: '',
+          password: '',
+        },
+      },
+    ],
+  ],
+};
+```
+
+
 ### Proxy
 
 If you use a proxy to access Jira, you need to configure the proxy. This proxy information will be used by Axios to send the results to Jira.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 // playwright.config.ts
 import type { PlaywrightTestConfig } from "@playwright/test";
+import { userInfo } from "os";
 
 const config: PlaywrightTestConfig = {
   reporter: [
@@ -17,6 +18,8 @@ const config: PlaywrightTestConfig = {
         },
         server: {
           token: "",
+          username: "",
+          password: "",
         },
         projectKey: "CODE",
         testPlan: "CODE-1820",

--- a/src/types/xray.types.ts
+++ b/src/types/xray.types.ts
@@ -1,5 +1,19 @@
 import type { AxiosProxyConfig } from 'axios';
 
+type ServerWithToken = {
+  token: string;
+  username?: never;
+  password?: never;
+};
+
+type ServerWithBasicAuth = {
+  token?: never;
+  username: string;
+  password: string;
+};
+
+type Server = ServerWithToken | ServerWithBasicAuth;
+
 export interface XrayOptions {
   jira: {
     url: string;
@@ -11,9 +25,7 @@ export interface XrayOptions {
     client_secret?: string;
     xrayUrl?: string;
   };
-  server?: {
-    token: string;
-  };
+  server?: Server;
   projectKey: string;
   testPlan: string;
   testExecution?: string;

--- a/src/xray.service.ts
+++ b/src/xray.service.ts
@@ -267,15 +267,26 @@ export class XrayService {
         // Set Xray Server URL
         if (!options.jira?.url) throw new Error('"host" option is missed. Please, provide it in the config');
         xray = options.jira?.url;
-
+        
         // Set Xray Credencials
-        if (!options.server?.token) throw new Error('"server.token" option is missing. Please provide them in the config');
-        token = options.server?.token;
+        if(options.server) {
+          if('token' in options.server) {
+            token = options.server.token as string;
+          } else if('username' in options.server && 'password' in options.server) {
+            username = options.server.username as string;
+            password = options.server.password as string;
+          } else {
+            throw new Error(
+              '"server.token" or "server.username & server.password" options are missing. Please provide either token or username and password in the config',
+            );
+          }
+        }
 
         // Set Request URL
         this.requestUrl = xray + (this.apiVersion !== '1.0' ? `rest/raven/${this.apiVersion}/api` : 'rest/raven/1.0');
 
         //Create Axios Instance with Auth
+        if (token) {
         this.axios = axios.create({
           baseURL: xray,
           headers: {
@@ -283,6 +294,19 @@ export class XrayService {
             Authorization: `Bearer ${token}`,
           },
         });
+      }
+      if (username && password) {
+        this.axios = axios.create({
+          baseURL: xray,
+          auth: {
+            username,
+            password,
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      }
 
         break;
     }


### PR DESCRIPTION
Our project would benefit from having support for the basic authentication method and using a username and password.
So we are modifying the setup a bit to either require a token or combination of username and password if the server option is used.