### PR TITLE
Enhance XrayOptions to support partial JiraXrayStatusMapping overwrite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,7 @@ class XrayReporter implements Reporter {
       uploadTrace: this.uploadTrace,
       uploadVideo: this.uploadVideo,
       jiraType: this.options.jira.type,
+      jiraXrayStatusMapping: this.options.jiraXrayStatusMapping,
     });
 
     if (typeof this.testResults !== 'undefined' && typeof this.testResults.tests !== 'undefined' && this.testResults.tests.length > 0) {

--- a/src/types/xray.types.ts
+++ b/src/types/xray.types.ts
@@ -14,6 +14,14 @@ type ServerWithBasicAuth = {
 
 type Server = ServerWithToken | ServerWithBasicAuth;
 
+export type JiraXrayStatusMapping = {
+  passed: string;
+  failed: string;
+  skipped: string;
+  timedOut: string;
+  interrupted: string;
+};
+
 export interface XrayOptions {
   jira: {
     url: string;
@@ -44,4 +52,5 @@ export interface XrayOptions {
   dryRun?: boolean;
   runResult?: boolean;
   projectsToExclude?: string | string[];
+  jiraXrayStatusMapping?: Partial<JiraXrayStatusMapping>;
 }


### PR DESCRIPTION
- Add `Partial<JiraXrayStatusMapping>` to `XrayOptions` for flexible status mapping overrides
- Extend `ConversionOptions` with `JiraXrayStatusMapping`
- Integrate logic to overwrite Jira Xray state within `getIterationStatus`