### PR TITLE
[FEATURE] Allow exclude fields for test execution creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## ⚠️ This is a fork
+
+This project is a fork of:
+https://github.com/inluxc/playwright-xray
+
+Original author: Fúlvio Carvalhido
+
+Changes in this fork:
+- The project accept a new parameter `fieldsToExclude` inside the `playwright config file` that indicates which fields are not going to be sent to Jira to create the test execution record
+
+This fork is maintained independently and is not affiliated with the original project.
+
 # Xray reporter for Playwright
 
 Publish Playwright test run on Xray
@@ -11,7 +23,7 @@ Thanks Yevhen for the great contribution
 ## Install
 
 ```sh
-npm i -D playwright-xray
+npm i -D playwright-xray-custom
 ```
 
 ## Usage
@@ -168,7 +180,8 @@ const config: PlaywrightTestConfig = {
           skipped: "SKIPPED",
           timedOut: "FAIL",
           interrupted: "ABORTED",
-        }
+        },
+        fieldsToExclude: [field1, field2, ...]
       },
     ],
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "playwright-xray",
+  "name": "playwright-xray-custom",
   "version": "0.6.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "playwright-xray",
+      "name": "playwright-xray-custom",
       "version": "0.6.24",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "playwright-xray",
+  "name": "@yoanymoraathena/playwright-xray-custom",
   "version": "0.6.24",
-  "description": "XRAY reporter for the Playwright",
+  "description": "Fork of XRAY reporter for the Playwright with optional parameter that allows to create a Test Execution record without specified fields",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/inluxc/playwright-xray.git"
+    "url": "git+https://github.com/yoanymoraathena/playwright-xray-custom.git"
   },
   "keywords": [
     "playwright",
@@ -33,9 +33,9 @@
   "author": "Fúlvio Carvalhido <inluxc@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/inluxc/playwright-xray/issues"
+    "url": "https://github.com/yoanymoraathena/playwright-xray-custom.git/issues"
   },
-  "homepage": "https://github.com/inluxc/playwright-xray#readme",
+  "homepage": "https://github.com/yoanymoraathena/playwright-xray-custom.git#readme",
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@playwright/test": "^1.30.0",

--- a/src/types/cloud.types.ts
+++ b/src/types/cloud.types.ts
@@ -23,8 +23,9 @@ export interface XrayInfo {
   revision?: string;
   startDate: string;
   finishDate: string;
-  testPlanKey: string;
+  testPlanKey?: string;
   testEnvironments?: object;
+  [key: string]: any;
 }
 
 export interface XrayTest {

--- a/src/types/server.types.ts
+++ b/src/types/server.types.ts
@@ -23,6 +23,7 @@ export interface XrayInfo {
   revision: string;
   startDate: string;
   finishDate: string;
+  [key: string]: any;
 }
 
 export interface XrayTest {

--- a/src/types/xray.types.ts
+++ b/src/types/xray.types.ts
@@ -64,4 +64,5 @@ export interface XrayOptions {
     issuetype?: { id: string };
     components?: { name: string }[];
   };
+  fieldsToExclude?: string[];
 }

--- a/src/xray.service.ts
+++ b/src/xray.service.ts
@@ -5,7 +5,7 @@ import FormData from "form-data";
 import { blue, bold, green, red, white, yellow } from "picocolors";
 import { convertToMultipart, verifyMultipatConfig } from "./convertToMultipart";
 import Help from "./help";
-import type { XrayTest as XrayTestCloud, XrayTestResult as XrayTestResultCloud } from "./types/cloud.types";
+import type { XrayInfo, XrayTest as XrayTestCloud, XrayTestResult as XrayTestResultCloud } from "./types/cloud.types";
 import type { ExecInfo } from "./types/execInfo.types";
 import type { XrayTestResult as XrayTestResultServer, XrayTest as XrayTestServer } from "./types/server.types";
 import type { XrayOptions } from "./types/xray.types";
@@ -25,6 +25,7 @@ export class XrayService {
   private runResult: boolean;
   private limitEvidenceSize: number;
   private isXrayCloudAuthenticated = false;
+  private fieldsToExclude: string[] | undefined;
 
   constructor(options: XrayOptions) {
     // Init vars
@@ -33,7 +34,7 @@ export class XrayService {
     this.dryRun = options.dryRun === true;
     this.runResult = options.runResult === true;
     this.limitEvidenceSize = options.limitEvidenceSize === undefined ? 104857600 : options.limitEvidenceSize;
-
+    this.fieldsToExclude = options.fieldsToExclude;
     // Set Jira URL
     if (!options.jira.url) throw new Error('"jira.url" option is missed. Please, provide it in the config');
     this.jira = options.jira.url;
@@ -76,10 +77,17 @@ export class XrayService {
     if (!options.testPlan) throw new Error('"testPlan" option are missed. Please provide them in the config');
   }
 
+  removeExcludedFields(testResultsInfo: XrayInfo, fieldsToExclude: string[]) {
+    fieldsToExclude.forEach((field) => {
+        delete testResultsInfo[field];
+    });
+  }
+
   async createRun(results: XrayTestResult, execInfo: ExecInfo) {
     const URL = `${this.requestUrl}/import/execution`;
     const total = results.tests?.length;
     const duration = new Date(results.info.finishDate).getTime() - new Date(results.info.startDate).getTime();
+    if (this.fieldsToExclude) this.removeExcludedFields(results.info, this.fieldsToExclude);
     let passed = 0;
     let failed = 0;
     let flaky = 0;


### PR DESCRIPTION
- Include `fieldsToExclude` parameter to indicate which fields shouldn't be taking into account when sending the payload to Jira to create a test execution record.
- Update README and package.json files to indicate this is a forked version of the library.