### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ on:
         required: true
         default: 'latest'
 
+permissions:
+  contents: write
+
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/inluxc/playwright-xray/security/code-scanning/3](https://github.com/inluxc/playwright-xray/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/release.yaml` so the workflow does not inherit potentially broad defaults.  
Best single fix without changing functionality: define permissions at the workflow root (applies to all jobs unless overridden), granting only what this release pipeline likely needs:
- `contents: write` (for creating/updating tags/releases during `npm run release:ci`).

No imports, methods, or extra definitions are needed—just YAML config in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
