### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -3,6 +3,9 @@ name: Code quality
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/inluxc/playwright-xray/security/code-scanning/2](https://github.com/inluxc/playwright-xray/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/codequality.yml` at the workflow root so it applies to all jobs in this workflow. For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves current functionality (`checkout` + running Biome) while ensuring `GITHUB_TOKEN` is not granted broader default permissions. No imports, methods, or external definitions are needed; this is a YAML configuration-only change. Insert the block after the `on` section (or before `jobs`) so structure remains clear and valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
