### PR TITLE
Cant find what projec was selected from command line

### DIFF
--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,5 +1,5 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 import { getArg } from "./args";
 
 const ORIGINAL_ARGV = process.argv;

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,0 +1,151 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getArg } from "./args";
+
+const ORIGINAL_ARGV = process.argv;
+const ORIGINAL_ENV = { ...process.env };
+
+function setArgv(args: string[]) {
+  process.argv = ["node", "script.js", ...args];
+}
+
+function resetEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+function reset() {
+  process.argv = ORIGINAL_ARGV;
+  resetEnv();
+}
+
+// -------------------------
+// CLI parsing
+// -------------------------
+
+test("reads --key=value format", () => {
+  setArgv(["--project=chromium"]);
+
+  assert.equal(getArg("project"), "chromium");
+
+  reset();
+});
+
+test("reads --key value format", () => {
+  setArgv(["--project", "firefox"]);
+
+  assert.equal(getArg("project"), "firefox");
+
+  reset();
+});
+
+test("reads boolean flag", () => {
+  setArgv(["--dryRun"]);
+
+  assert.equal(getArg("dryRun"), true);
+
+  reset();
+});
+
+test("reads short flag", () => {
+  setArgv(["-v"]);
+
+  assert.equal(getArg("v"), true);
+
+  reset();
+});
+
+test("returns undefined for missing flag", () => {
+  setArgv([]);
+
+  assert.equal(getArg("missing"), undefined);
+
+  reset();
+});
+
+// -------------------------
+// npm_config fallback
+// -------------------------
+
+test("reads npm_config fallback", () => {
+  setArgv([]);
+
+  process.env.npm_config_runid = "123";
+
+  assert.equal(getArg("runid"), "123");
+
+  reset();
+});
+
+// -------------------------
+// ENV fallback
+// -------------------------
+
+test("reads ENV fallback", () => {
+  setArgv([]);
+
+  process.env.RUNID = "456";
+
+  assert.equal(getArg("runid"), "456");
+
+  reset();
+});
+
+// -------------------------
+// priority order
+// -------------------------
+
+test("CLI overrides npm_config and ENV", () => {
+  setArgv(["--runid=cli"]);
+
+  process.env.npm_config_runid = "npm";
+  process.env.RUNID = "env";
+
+  assert.equal(getArg("runid"), "cli");
+
+  reset();
+});
+
+test("npm_config overrides ENV", () => {
+  setArgv([]);
+
+  process.env.npm_config_runid = "npm";
+  process.env.RUNID = "env";
+
+  assert.equal(getArg("runid"), "npm");
+
+  reset();
+});
+
+// -------------------------
+// default values
+// -------------------------
+
+test("returns default when nothing set", () => {
+  setArgv([]);
+
+  assert.equal(getArg("runid", { default: "local" }), "local");
+
+  reset();
+});
+
+// -------------------------
+// edge cases
+// -------------------------
+
+test("handles multiple flags", () => {
+  setArgv(["--project=chromium", "--dryRun", "--runid=abc"]);
+
+  assert.equal(getArg("project"), "chromium");
+  assert.equal(getArg("dryRun"), true);
+  assert.equal(getArg("runid"), "abc");
+
+  reset();
+});
+
+test("handles flag without explicit value", () => {
+  setArgv(["--runid"]);
+
+  assert.equal(getArg("runid"), true);
+
+  reset();
+});

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,61 @@
+type ParsedArgs = {
+  flags: Record<string, string | boolean>;
+  positional: string[];
+};
+
+function parseArgs(): ParsedArgs {
+  const raw = process.argv.slice(2);
+
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < raw.length; i++) {
+    const arg = raw[i];
+
+    if (arg.startsWith("--")) {
+      const [key, value] = arg.split("=");
+
+      if (value !== undefined) {
+        flags[key.slice(2)] = value;
+      } else {
+        const next = raw[i + 1];
+        if (next && !next.startsWith("-")) {
+          flags[key.slice(2)] = next;
+          i++;
+        } else {
+          flags[key.slice(2)] = true;
+        }
+      }
+    } else if (arg.startsWith("-")) {
+      flags[arg.slice(1)] = true;
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { flags, positional };
+}
+
+// Public API for your reporter
+export function getArg(name: string, options?: { default?: string }): string | boolean | undefined {
+  const { flags } = parseArgs();
+
+  // 1. CLI: --myFlag=value
+  if (flags[name] !== undefined) {
+    return flags[name];
+  }
+
+  // 2. npm_config_ fallback (npm run --flag=value)
+  const npmValue = process.env[`npm_config_${name}`];
+  if (npmValue !== undefined) {
+    return npmValue;
+  }
+
+  // 3. ENV fallback (CI-friendly)
+  const envValue = process.env[name.toUpperCase()];
+  if (envValue !== undefined) {
+    return envValue;
+  }
+
+  return options?.default;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,6 @@ class XrayReporter implements Reporter {
       projectsToReport.push(this.execInfo.testedBrowser);
     }
 
-    console.log(definedProjects);
     // Exclude projects from the report
     // If the projectsToExclude is an array, we will use the regex to exclude the projects
     if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== "string" && this.projectsToExclude.length > 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ class XrayReporter implements Reporter {
 
   async onBegin(config: FullConfig, suite: Suite) {
     try {
-      this.setProjectToReport(suite, config);
+      this.setProjectToReport(config);
     } catch (error) {
       throw new Error(`Failed to obtain project with error: ${error}`);
     }
@@ -163,11 +163,8 @@ class XrayReporter implements Reporter {
   }
 
   // biome-ignore lint/complexity/noBannedTypes: Allow for {}
-  private setProjectToReport(suite: Suite, config: FullConfig<{}, {}>) {
+  private setProjectToReport(config: FullConfig<{}, {}>) {
     const projectsToReport: string[] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: Allow for any
-    const entries: Array<any> = (suite as any)._entries;
-    const definedProjects = entries.flatMap((o) => o._fullProject.id);
 
     if (this.execInfo.testedBrowser !== undefined) {
       projectsToReport.push(this.execInfo.testedBrowser);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { FullConfig, FullResult, Reporter, Suite, TestCase, TestResult } from "@playwright/test/reporter";
 import { blue, bold, green, magenta, red, white, yellow } from "picocolors";
+import { getArg } from "./args";
 import { convertToXrayJson } from "./convert";
 import Help from "./help";
 import type { XrayTest, XrayTestResult } from "./types/cloud.types";
@@ -50,12 +51,13 @@ class XrayReporter implements Reporter {
       tests: [] as XrayTest[],
     };
     this.projectsToExclude = this.options.projectsToExclude;
+    const args = getArg("project");
     console.log(`${bold(blue("-------------------------------------"))}`);
     console.log(`${bold(blue(" "))}`);
     if (this.options.summary !== undefined) this.testResults.info.summary = this.options.summary;
     this.execInfo = {
       browserName: "",
-      testedBrowser: undefined,
+      testedBrowser: typeof args === "boolean" ? undefined : args,
     };
   }
 
@@ -90,7 +92,10 @@ class XrayReporter implements Reporter {
     const testCaseId = testCase.title.match(this.testCaseKeyPattern);
     const testCodes: string = testCaseId?.[1] ?? "";
     const projectId = JSON.stringify(testCase.parent.project()).match(/__projectId":"(.*)"/)?.[1];
-    if (this.execInfo.testedBrowser !== projectId) {
+    if (this.execInfo.testedBrowser?.toLowerCase() !== projectId?.toLocaleLowerCase()) {
+      console.log(
+        `${bold(white("⏺  "))}${bold(white(`Test case ${testCase.title} does not belong to the selected project. Running in project "${projectId}"`))}`,
+      );
       return;
     }
 
@@ -162,10 +167,13 @@ class XrayReporter implements Reporter {
     const projectsToReport: string[] = [];
     // biome-ignore lint/suspicious/noExplicitAny: Allow for any
     const entries: Array<any> = (suite as any)._entries;
-    const cliArguments = entries.flatMap((o) => o._fullProject.fullConfig.cliProjectFilter);
-    if (cliArguments !== undefined && cliArguments[0] !== undefined) {
-      projectsToReport.push(cliArguments[0]);
+    const definedProjects = entries.flatMap((o) => o._fullProject.id);
+
+    if (this.execInfo.testedBrowser !== undefined) {
+      projectsToReport.push(this.execInfo.testedBrowser);
     }
+
+    console.log(definedProjects);
     // Exclude projects from the report
     // If the projectsToExclude is an array, we will use the regex to exclude the projects
     if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== "string" && this.projectsToExclude.length > 1) {


### PR DESCRIPTION
# Description
If there are several projects, the reporter ignores the one chosen with the cli parameter --project

Fixes # (issue)
The suite  object in the function onBegin had an entry _entries._fullProject.fullConfig.cliProjectFilter that contained the selected project, but it is not there any more.

## Type of change
Notices that Playwright provides the argv to the plugin, so this fix will use that insetead

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran apart from biome to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] npx biome check
- [x] npx playwright test "convert.test.ts" -g "\s+\S+"



# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
