### PR TITLE
#97 fix multi project

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,12 +428,16 @@ And you'll see the result in the Xray:
 
 ## Multiple Projects
 
-If you need to run multiple browsers, you need to use the project switch and run them after each other, e.g.
+If your `playwright.config.ts` defines multiple projects (e.g. multiple browsers, or projects with
+dependencies such as `setup`/`teardown`), all projects run in a single Playwright invocation are now
+reported and imported into the same Xray Test Execution.
+
+If you only want to report a single project, run with `--project=<name>`:
 ```console
-npx playwright test --project=Chrome 
-npx playwright test --project=Firefox
+npx playwright test --project=Chrome
 ```
-If multiple projects are selected in one run, only the first will be reported and imported to Xray. 
+
+To report all projects except a specific few, use the `projectsToExclude` option instead (see above).
 
 ## Multiple Test Plans
 

--- a/README.md
+++ b/README.md
@@ -519,11 +519,28 @@ for (const name of ['Jane', 'John', 'Mary']) {
 
 When uploading, evidence for individual test runs is added to the test execution itself, as Xray does not support adding evidence to iterations outside of steps.
 
+If the same test key runs in more than one Playwright project (e.g. multiple browsers, or dependent
+projects), each iteration is labeled with the project name instead of a plain counter:
+
+```typescript
+// runs in both the "Chrome" and "Firefox" projects
+test(`PWXR-3 | basic test`, async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+});
+```
+
+This is shown in Xray as `Iteration 1 - Chrome`, `Iteration 2 - Firefox`, etc., instead of a plain
+`Iteration 1 - 1`, `Iteration 2 - 2`.
+
 The reporter calculates Xray statuses for tests with iterations as follows:
 
-- tests with iterations are considered passed if at least one iteration passed
-- tests with iterations are considered failed if all iterations failed or timed out
-- if there is at least one passed iteration, one failed iteration _and_ the the flaky flag is defined, the test will be reported as flaky
+- results are first grouped by Playwright project; within a project, retries are flaky-forgiving, i.e. that
+  project counts as passed if at least one of its attempts passed
+- across projects, a genuine failure in any one project is never masked by another project passing: if any
+  project's results failed or timed out, the whole test is reported as failed
+- otherwise, if at least one project passed, the test is reported as passed
+
+See the `markFlakyWith` option in the [Notes](#notes) section below for how a test that only passed after a retry is tagged.
 
 ## Expose reporter options type
 In order to enable IntelliSense to provide useful suggestions and avoid potential typos not being detected,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "release:minor": "npm run release -- minor",
     "release:major": "npm run release -- major",
     "format": "biome format --write",
-    "test": "npx playwright test simple.test.ts"
+    "test": "npx playwright test simple.test.ts",
+    "test:multi-project": "npx playwright test --config=playwright.multi-project.config.ts"
   },
   "repository": {
     "type": "git",

--- a/playwright.multi-project.config.ts
+++ b/playwright.multi-project.config.ts
@@ -4,6 +4,7 @@ import type { PlaywrightTestConfig } from "@playwright/test";
 // reported into a single Xray execution, not just the first project.
 const config: PlaywrightTestConfig = {
   testDir: "./tests/multi-project",
+  retries: 1,
   reporter: [
     [
       "./src/index.ts",

--- a/playwright.multi-project.config.ts
+++ b/playwright.multi-project.config.ts
@@ -1,0 +1,45 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+// a "setup" project plus two dependent browser projects must all be
+// reported into a single Xray execution, not just the first project.
+const config: PlaywrightTestConfig = {
+  testDir: "./tests/multi-project",
+  reporter: [
+    [
+      "./src/index.ts",
+      {
+        jira: {
+          url: "https://client.atlassian.net/",
+          type: "cloud",
+          apiVersion: "1.0",
+        },
+        cloud: {
+          client_id: "",
+          client_secret: "",
+        },
+        projectKey: "CODE",
+        testPlan: "CODE-1820",
+        dryRun: true,
+      },
+    ],
+  ],
+  projects: [
+    {
+      name: "setup",
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: "Chrome",
+      use: { browserName: "chromium" },
+      testMatch: /chrome\.test\.ts/,
+      dependencies: ["setup"],
+    },
+    {
+      name: "Firefox",
+      use: { browserName: "firefox" },
+      testMatch: /firefox\.test\.ts/,
+      dependencies: ["setup"],
+    },
+  ],
+};
+export default config;

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,5 +1,5 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 import { getArg } from "./args";
 
 const ORIGINAL_ARGV = process.argv;

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,0 +1,151 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getArg } from "./args";
+
+const ORIGINAL_ARGV = process.argv;
+const ORIGINAL_ENV = { ...process.env };
+
+function setArgv(args: string[]) {
+  process.argv = ["node", "script.js", ...args];
+}
+
+function resetEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+function reset() {
+  process.argv = ORIGINAL_ARGV;
+  resetEnv();
+}
+
+// -------------------------
+// CLI parsing
+// -------------------------
+
+test("reads --key=value format", () => {
+  setArgv(["--project=chromium"]);
+
+  assert.equal(getArg("project"), "chromium");
+
+  reset();
+});
+
+test("reads --key value format", () => {
+  setArgv(["--project", "firefox"]);
+
+  assert.equal(getArg("project"), "firefox");
+
+  reset();
+});
+
+test("reads boolean flag", () => {
+  setArgv(["--dryRun"]);
+
+  assert.equal(getArg("dryRun"), true);
+
+  reset();
+});
+
+test("reads short flag", () => {
+  setArgv(["-v"]);
+
+  assert.equal(getArg("v"), true);
+
+  reset();
+});
+
+test("returns undefined for missing flag", () => {
+  setArgv([]);
+
+  assert.equal(getArg("missing"), undefined);
+
+  reset();
+});
+
+// -------------------------
+// npm_config fallback
+// -------------------------
+
+test("reads npm_config fallback", () => {
+  setArgv([]);
+
+  process.env.npm_config_runid = "123";
+
+  assert.equal(getArg("runid"), "123");
+
+  reset();
+});
+
+// -------------------------
+// ENV fallback
+// -------------------------
+
+test("reads ENV fallback", () => {
+  setArgv([]);
+
+  process.env.RUNID = "456";
+
+  assert.equal(getArg("runid"), "456");
+
+  reset();
+});
+
+// -------------------------
+// priority order
+// -------------------------
+
+test("CLI overrides npm_config and ENV", () => {
+  setArgv(["--runid=cli"]);
+
+  process.env.npm_config_runid = "npm";
+  process.env.RUNID = "env";
+
+  assert.equal(getArg("runid"), "cli");
+
+  reset();
+});
+
+test("npm_config overrides ENV", () => {
+  setArgv([]);
+
+  process.env.npm_config_runid = "npm";
+  process.env.RUNID = "env";
+
+  assert.equal(getArg("runid"), "npm");
+
+  reset();
+});
+
+// -------------------------
+// default values
+// -------------------------
+
+test("returns default when nothing set", () => {
+  setArgv([]);
+
+  assert.equal(getArg("runid", { default: "local" }), "local");
+
+  reset();
+});
+
+// -------------------------
+// edge cases
+// -------------------------
+
+test("handles multiple flags", () => {
+  setArgv(["--project=chromium", "--dryRun", "--runid=abc"]);
+
+  assert.equal(getArg("project"), "chromium");
+  assert.equal(getArg("dryRun"), true);
+  assert.equal(getArg("runid"), "abc");
+
+  reset();
+});
+
+test("handles flag without explicit value", () => {
+  setArgv(["--runid"]);
+
+  assert.equal(getArg("runid"), true);
+
+  reset();
+});

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,61 @@
+type ParsedArgs = {
+  flags: Record<string, string | boolean>;
+  positional: string[];
+};
+
+function parseArgs(): ParsedArgs {
+  const raw = process.argv.slice(2);
+
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < raw.length; i++) {
+    const arg = raw[i];
+
+    if (arg.startsWith("--")) {
+      const [key, value] = arg.split("=");
+
+      if (value !== undefined) {
+        flags[key.slice(2)] = value;
+      } else {
+        const next = raw[i + 1];
+        if (next && !next.startsWith("-")) {
+          flags[key.slice(2)] = next;
+          i++;
+        } else {
+          flags[key.slice(2)] = true;
+        }
+      }
+    } else if (arg.startsWith("-")) {
+      flags[arg.slice(1)] = true;
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { flags, positional };
+}
+
+// Public API for your reporter
+export function getArg(name: string, options?: { default?: string }): string | boolean | undefined {
+  const { flags } = parseArgs();
+
+  // 1. CLI: --myFlag=value
+  if (flags[name] !== undefined) {
+    return flags[name];
+  }
+
+  // 2. npm_config_ fallback (npm run --flag=value)
+  const npmValue = process.env[`npm_config_${name}`];
+  if (npmValue !== undefined) {
+    return npmValue;
+  }
+
+  // 3. ENV fallback (CI-friendly)
+  const envValue = process.env[name.toUpperCase()];
+  if (envValue !== undefined) {
+    return envValue;
+  }
+
+  return options?.default;
+}

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -27,20 +27,28 @@ type XrayTestEvidence = XrayTestEvidenceServer | XrayTestEvidenceCloud;
 type XrayIterationParameter = XrayIterationParameterServer | XrayIterationParameterCloud;
 
 /**
+ * A single Playwright test result together with the name of the project that produced it.
+ */
+export type TestResultEntry = {
+  result: TestResult;
+  project?: string;
+};
+
+/**
  * Converts a map of issue keys and Playwright test results to Xray JSON. If there are multiple tests grouped under a single issue key, a
  * corresponding Xray test with iterations will be returned. Otherwise, a single Xray test will be returned without iteration data.
  *
- * Note: it does not matter where the results come from. They can be retries or they can be data-driven results for a single test. Both will
- * be converted to iterations accordingly.
+ * Note: it does not matter where the results come from. They can be retries, data-driven results for a single test, or results from
+ * different Playwright projects (e.g. multiple browsers or dependent projects). All will be converted to iterations accordingly.
  *
  * @param groupedResults the mapping of issue keys to Playwright results
  * @param options additional conversion options
  * @returns the corresponding Xray test JSON
  */
-export async function convertToXrayJson(groupedResults: Map<string, TestResult[]>, options: ConversionOptions): Promise<XrayTest[]> {
+export async function convertToXrayJson(groupedResults: Map<string, TestResultEntry[]>, options: ConversionOptions): Promise<XrayTest[]> {
   const xrayTests: XrayTest[] = [];
-  for (const [issueKey, results] of groupedResults) {
-    xrayTests.push(await getTest(issueKey, results, options));
+  for (const [issueKey, entries] of groupedResults) {
+    xrayTests.push(await getTest(issueKey, entries, options));
   }
   return xrayTests;
 }
@@ -55,35 +63,44 @@ type ConversionOptions = {
   jiraXrayStatusMapping?: Partial<JiraXrayStatusMapping>;
 };
 
-async function getTest(issueKey: string, results: TestResult[], options: ConversionOptions): Promise<XrayTest> {
+async function getTest(issueKey: string, entries: TestResultEntry[], options: ConversionOptions): Promise<XrayTest> {
   const help = new Help(options.jiraType);
+  const results = entries.map((entry) => entry.result);
   let xrayTest: XrayTest;
 
   if (options.jiraType === "cloud") {
     xrayTest = {
-      status: getTestStatus(results, options),
+      status: getTestStatus(entries, options),
       testKey: issueKey,
       evidence: await getEvidences(results, options),
     };
   } else {
     xrayTest = {
-      status: getTestStatus(results, options),
+      status: getTestStatus(entries, options),
       testKey: issueKey,
       evidences: await getEvidences(results, options),
     };
   }
 
-  if (results.length > 1) {
+  if (entries.length > 1) {
+    // If the same test key produced results across more than one Playwright project (e.g. multiple
+    // browsers, or dependent projects), label each iteration with its project name instead of a plain
+    // counter, since Xray already numbers iterations itself.
+    const distinctProjects = new Set(entries.map((entry) => entry.project).filter((project): project is string => !!project));
     const iterations: XrayTestIteration[] = [];
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i];
+    for (let i = 0; i < entries.length; i++) {
+      const { result, project } = entries[i];
       const metadata = getXrayMetadata(result);
       const iterationParameters: XrayIterationParameter[] = Object.entries(metadata?.parameters ?? {}).map(([key, value]) => {
         return { name: key, value: value };
       });
+      const iterationParameter: XrayIterationParameter =
+        distinctProjects.size > 1 && project !== undefined
+          ? { name: "project", value: project }
+          : { name: "iteration", value: (iterations.length + 1).toString() };
       iterations.push({
         status: getIterationStatus(result.status, options),
-        parameters: [{ name: "iteration", value: (iterations.length + 1).toString() }, ...iterationParameters],
+        parameters: [iterationParameter, ...iterationParameters],
         steps: getSteps(result, options),
       });
     }
@@ -102,18 +119,59 @@ async function getTest(issueKey: string, results: TestResult[], options: Convers
   return xrayTest;
 }
 
-function getTestStatus(iterations: TestResult[], options: ConversionOptions) {
-  if (iterations.every((iteration) => iteration.status === "failed" || iteration.status === "timedOut")) {
-    return getIterationStatus("failed", options);
+type AggregateStatus = "failed" | "interrupted" | "skipped" | "passed";
+
+/**
+ * Determines the overall status for a test key across all of its results.
+ *
+ * Results are first grouped by Playwright project. Within a project, retries are flaky-forgiving
+ * (one passing attempt is enough for that project to count as passed) - but a project that genuinely
+ * failed is never masked by another project passing: any project failing fails the whole test.
+ */
+function getTestStatus(entries: TestResultEntry[], options: ConversionOptions) {
+  const resultsByProject = groupResultsByProject(entries);
+  const projectStatuses = resultsByProject.map((results) => getAggregateStatus(results));
+
+  let overall: AggregateStatus;
+  if (projectStatuses.includes("failed")) {
+    overall = "failed";
+  } else if (projectStatuses.includes("interrupted")) {
+    overall = "interrupted";
+  } else if (projectStatuses.every((status) => status === "skipped")) {
+    overall = "skipped";
+  } else {
+    // Note: flaky tests are also considered passing by default.
+    overall = "passed";
   }
-  if (iterations.some((iteration) => iteration.status === "interrupted")) {
-    return getIterationStatus("interrupted", options);
+
+  return getIterationStatus(overall, options);
+}
+
+function getAggregateStatus(results: TestResult[]): AggregateStatus {
+  if (results.every((result) => result.status === "failed" || result.status === "timedOut")) {
+    return "failed";
   }
-  if (iterations.every((iteration) => iteration.status === "skipped")) {
-    return getIterationStatus("skipped", options);
+  if (results.some((result) => result.status === "interrupted")) {
+    return "interrupted";
   }
-  // Note: flaky tests are also considered passing by default.
-  return getIterationStatus("passed", options);
+  if (results.every((result) => result.status === "skipped")) {
+    return "skipped";
+  }
+  return "passed";
+}
+
+function groupResultsByProject(entries: TestResultEntry[]): TestResult[][] {
+  const resultsByProject = new Map<string, TestResult[]>();
+  for (const entry of entries) {
+    const project = entry.project ?? "";
+    const results = resultsByProject.get(project);
+    if (results) {
+      results.push(entry.result);
+    } else {
+      resultsByProject.set(project, [entry.result]);
+    }
+  }
+  return [...resultsByProject.values()];
 }
 
 function getIterationStatus(status: TestStatus, options: ConversionOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,6 @@ class XrayReporter implements Reporter {
       projectsToReport.push(this.execInfo.testedBrowser);
     }
 
-    console.log(definedProjects);
     // Exclude projects from the report
     // If the projectsToExclude is an array, we will use the regex to exclude the projects
     if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== "string" && this.projectsToExclude.length > 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ class XrayReporter implements Reporter {
 
   async onBegin(config: FullConfig, suite: Suite) {
     try {
-      this.setProjectToReport(suite, config);
+      this.setProjectToReport(config);
     } catch (error) {
       throw new Error(`Failed to obtain project with error: ${error}`);
     }
@@ -163,11 +163,8 @@ class XrayReporter implements Reporter {
   }
 
   // biome-ignore lint/complexity/noBannedTypes: Allow for {}
-  private setProjectToReport(suite: Suite, config: FullConfig<{}, {}>) {
+  private setProjectToReport(config: FullConfig<{}, {}>) {
     const projectsToReport: string[] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: Allow for any
-    const entries: Array<any> = (suite as any)._entries;
-    const definedProjects = entries.flatMap((o) => o._fullProject.id);
 
     if (this.execInfo.testedBrowser !== undefined) {
       projectsToReport.push(this.execInfo.testedBrowser);

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ class XrayReporter implements Reporter {
     if (this.options.summary !== undefined) this.testResults.info.summary = this.options.summary;
     this.execInfo = {
       browserName: "",
-      testedBrowser: typeof args === "boolean" ? undefined : args,
+      testedBrowsers: typeof args === "boolean" || args === undefined ? undefined : [args],
     };
   }
 
@@ -75,24 +75,27 @@ class XrayReporter implements Reporter {
     }
 
     console.log(`${bold(blue(" "))}`);
-    if (this.execInfo.testedBrowser !== undefined) {
+    if (this.execInfo.testedBrowsers !== undefined) {
       console.log(
-        `${bold(yellow("⏺  "))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowser}`))}`,
+        `${bold(yellow("⏺  "))}${bold(blue(`The following test execution will be imported & reported:  ${this.execInfo.testedBrowsers.join(", ")}`))}`,
       );
     }
   }
 
   async onTestBegin(_test: TestCase) {
-    if (this.execInfo.testedBrowser === undefined) {
+    if (this.execInfo.testedBrowsers === undefined) {
       console.log(`${bold(yellow("⏺  "))}${bold(red("No projects to run, have you excluded all in your playwright config?"))}`);
       return;
     }
   }
+
   async onTestEnd(testCase: TestCase, result: TestResult) {
     const testCaseId = testCase.title.match(this.testCaseKeyPattern);
     const testCodes: string = testCaseId?.[1] ?? "";
     const projectId = JSON.stringify(testCase.parent.project()).match(/__projectId":"(.*)"/)?.[1];
-    if (this.execInfo.testedBrowser?.toLowerCase() !== projectId?.toLocaleLowerCase()) {
+
+    const normalizedTestedBrowsers = this.execInfo.testedBrowsers?.map((b) => b.toLowerCase());
+    if (!normalizedTestedBrowsers?.includes(projectId?.toLowerCase() ?? "")) {
       console.log(
         `${bold(white("⏺  "))}${bold(white(`Test case ${testCase.title} does not belong to the selected project. Running in project "${projectId}"`))}`,
       );
@@ -166,13 +169,12 @@ class XrayReporter implements Reporter {
   private setProjectToReport(config: FullConfig<{}, {}>) {
     const projectsToReport: string[] = [];
 
-    if (this.execInfo.testedBrowser !== undefined) {
-      projectsToReport.push(this.execInfo.testedBrowser);
-    }
-
-    // Exclude projects from the report
-    // If the projectsToExclude is an array, we will use the regex to exclude the projects
-    if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== "string" && this.projectsToExclude.length > 1) {
+    // If CLI --project was already resolved in the constructor, it wins outright —
+    if (this.execInfo.testedBrowsers !== undefined) {
+      projectsToReport.push(...this.execInfo.testedBrowsers);
+      // Exclude projects from the report
+      // If the projectsToExclude is an array, we will use the regex to exclude the projects
+    } else if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== "string" && this.projectsToExclude.length > 1) {
       this.removeExcludedProjects(config, this.projectsToExclude.join("|"), projectsToReport);
       // If the projectsToExclude is an array with one string, we will use the regex to exclude the projects
     } else if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== "string") {
@@ -187,18 +189,18 @@ class XrayReporter implements Reporter {
       }
     }
 
+    let browserNameBuilt = "";
     projectsToReport.forEach((p, index) => {
-      this.execInfo.browserName += index > 0 ? ", " : "";
-      this.execInfo.browserName += p.charAt(0).toUpperCase() + p.slice(1);
-      // Set the first browser as the tested browser
-      if (index === 0) {
-        this.execInfo.testedBrowser = p;
-        if (this.projectsToExclude?.includes(p))
-          console.log(
-            `${bold(yellow("⏺  "))}${bold(magenta(`Setting for projectsToExclude conflicts with CLI argument. Will go with CLI: ${p}`))}`,
-          );
+      browserNameBuilt += index > 0 ? ", " : "";
+      browserNameBuilt += p.charAt(0).toUpperCase() + p.slice(1);
+      if (index === 0 && this.projectsToExclude?.includes(p)) {
+        console.log(
+          `${bold(yellow("⏺  "))}${bold(magenta(`Setting for projectsToExclude conflicts with CLI argument. Will go with CLI: ${p}`))}`,
+        );
       }
     });
+    this.execInfo.browserName = browserNameBuilt;
+    this.execInfo.testedBrowsers = projectsToReport;
   }
 
   // biome-ignore lint/complexity/noBannedTypes: Allow for {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { FullConfig, FullResult, Reporter, Suite, TestCase, TestResult } from "@playwright/test/reporter";
 import { blue, bold, green, magenta, red, white, yellow } from "picocolors";
+import { getArg } from "./args";
 import { convertToXrayJson } from "./convert";
 import Help from "./help";
 import type { XrayTest, XrayTestResult } from "./types/cloud.types";
@@ -50,12 +51,13 @@ class XrayReporter implements Reporter {
       tests: [] as XrayTest[],
     };
     this.projectsToExclude = this.options.projectsToExclude;
+    const args = getArg("project");
     console.log(`${bold(blue("-------------------------------------"))}`);
     console.log(`${bold(blue(" "))}`);
     if (this.options.summary !== undefined) this.testResults.info.summary = this.options.summary;
     this.execInfo = {
       browserName: "",
-      testedBrowser: undefined,
+      testedBrowser: typeof args === "boolean" ? undefined : args,
     };
   }
 
@@ -90,7 +92,10 @@ class XrayReporter implements Reporter {
     const testCaseId = testCase.title.match(this.testCaseKeyPattern);
     const testCodes: string = testCaseId?.[1] ?? "";
     const projectId = JSON.stringify(testCase.parent.project()).match(/__projectId":"(.*)"/)?.[1];
-    if (this.execInfo.testedBrowser !== projectId) {
+    if (this.execInfo.testedBrowser?.toLowerCase() !== projectId?.toLocaleLowerCase()) {
+      console.log(
+        `${bold(white("⏺  "))}${bold(white(`Test case ${testCase.title} does not belong to the selected project. Running in project "${projectId}"`))}`,
+      );
       return;
     }
 
@@ -162,10 +167,13 @@ class XrayReporter implements Reporter {
     const projectsToReport: string[] = [];
     // biome-ignore lint/suspicious/noExplicitAny: Allow for any
     const entries: Array<any> = (suite as any)._entries;
-    const cliArguments = entries.flatMap((o) => o._fullProject.fullConfig.cliProjectFilter);
-    if (cliArguments !== undefined && cliArguments[0] !== undefined) {
-      projectsToReport.push(cliArguments[0]);
+    const definedProjects = entries.flatMap((o) => o._fullProject.id);
+
+    if (this.execInfo.testedBrowser !== undefined) {
+      projectsToReport.push(this.execInfo.testedBrowser);
     }
+
+    console.log(definedProjects);
     // Exclude projects from the report
     // If the projectsToExclude is an array, we will use the regex to exclude the projects
     if (this.projectsToExclude !== undefined && typeof this.projectsToExclude !== "string" && this.projectsToExclude.length > 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { FullConfig, FullResult, Reporter, Suite, TestCase, TestResult } from "@playwright/test/reporter";
 import { blue, bold, green, magenta, red, white, yellow } from "picocolors";
 import { getArg } from "./args";
-import { convertToXrayJson } from "./convert";
+import { convertToXrayJson, type TestResultEntry } from "./convert";
 import Help from "./help";
 import type { XrayTest, XrayTestResult } from "./types/cloud.types";
 import type { ExecInfo } from "./types/execInfo.types";
@@ -22,7 +22,7 @@ class XrayReporter implements Reporter {
   private uploadVideo: boolean | undefined;
   private projectsToExclude: string | string[] | undefined;
   private stepCategories = ["expect", "pw:api", "test.step"];
-  private readonly testsByKey: Map<string, TestResult[]>;
+  private readonly testsByKey: Map<string, TestResultEntry[]>;
   useMultipart: boolean | undefined;
 
   constructor(options: XrayOptions) {
@@ -111,11 +111,12 @@ class XrayReporter implements Reporter {
 
       for (const testCode of testCodeArray) {
         // Handle retries and data-driven tests for each test case ID
+        const entry: TestResultEntry = { result, project: projectId };
         const tests = this.testsByKey.get(testCode);
         if (!tests) {
-          this.testsByKey.set(testCode, [result]);
+          this.testsByKey.set(testCode, [entry]);
         } else {
-          tests.push(result);
+          tests.push(entry);
         }
       }
 

--- a/src/types/execInfo.types.ts
+++ b/src/types/execInfo.types.ts
@@ -1,4 +1,4 @@
 export interface ExecInfo {
   browserName?: string;
-  testedBrowser?: string;
+  testedBrowsers?: string[];
 }

--- a/src/xray.service.ts
+++ b/src/xray.service.ts
@@ -147,7 +147,7 @@ export class XrayService {
         console.log(`${bold(yellow("⏺  "))}${bold(blue(`Revision:          ${this.options.revision}`))}`);
       }
       if (execInfo.browserName !== undefined) {
-        console.log(`${bold(yellow("⏺  "))}${bold(blue(`Browser:           ${execInfo.testedBrowser}`))}`);
+        console.log(`${bold(yellow("⏺  "))}${bold(blue(`Browser:           ${execInfo.testedBrowsers}`))}`);
       }
       console.log(`${bold(yellow("⏺  "))}${bold(blue(`Test plan:         ${this.options.testPlan}`))}`);
       if (this.options.testExecution !== undefined) {
@@ -220,7 +220,7 @@ export class XrayService {
 
     function writeRunResult(testPlan: string) {
       const runResult = {
-        browser: execInfo.testedBrowser,
+        browser: execInfo.testedBrowsers,
         testPlan: testPlan,
         testDuration: duration,
         testsRun: total,

--- a/tests/multi-project/chrome.test.ts
+++ b/tests/multi-project/chrome.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "@playwright/test";
+
+test("PWXR-3 | basic test", async ({ page }) => {
+  await page.setContent("<h1>Hello</h1>");
+  await expect(page.locator("h1")).toHaveText("Hello");
+});

--- a/tests/multi-project/firefox.test.ts
+++ b/tests/multi-project/firefox.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "@playwright/test";
+
+test("PWXR-10 | basic test", async ({ page }) => {
+  await page.setContent("<h1>Hello</h1>");
+  await expect(page.locator("h1")).toHaveText("Hello");
+});

--- a/tests/multi-project/firefox.test.ts
+++ b/tests/multi-project/firefox.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("PWXR-10 | basic test", async ({ page }) => {
+test("PWXR-3 | failing basic test in ff", async ({ page }) => {
   await page.setContent("<h1>Hello</h1>");
-  await expect(page.locator("h1")).toHaveText("Hello");
+  await expect(page.locator("h1")).toHaveText("This iteration will fail");
 });

--- a/tests/multi-project/global.setup.ts
+++ b/tests/multi-project/global.setup.ts
@@ -1,0 +1,5 @@
+import { test } from "@playwright/test";
+
+test("PWXR-99 | setup task", async () => {
+  console.log("running setup");
+});


### PR DESCRIPTION
# Description

This PR fixes multi-project test runs (#97).                                                                                                                          
                                                                                                                                                                        
As stated in the source issue, only the first project was included in the published execution when running with multiple or dependent projects. With this fix, all  projects (except any explicitly excluded via --project or projectsToExclude) will be included in a single Xray execution, instead of only the first one. 
This branch is built on top of #181 (fixing #179) to avoid merge conflicts between the two fixes.   

Fixes #97 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update -> readme updated.

# How Has This Been Tested?

Please describe the tests that you ran apart from biome to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] npx biome check
- [x] npx playwright test "convert.test.ts" -g "\s+\S+"
- [x] created temp multi project config and tested against it: `npx playwright test --config=playwright.multi-project.config.ts`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
